### PR TITLE
Fixing exclude

### DIFF
--- a/lib/Console/Commands/Test.php
+++ b/lib/Console/Commands/Test.php
@@ -126,7 +126,7 @@ class Test extends Command implements Listener
             $options['include'] = "/$include/";
         }
 
-        if ($match = $input->getOption('exclude')) {
+        if ($exclude = $input->getOption('exclude')) {
             $options['exclude'] = "/$exclude/";
         }
 


### PR DESCRIPTION
Syntax error here when trying to use exclude in the Test command.
