### PR TITLE
Fix #12 in jacobstr/matura

### DIFF
--- a/lib/Core/ErrorHandler.php
+++ b/lib/Core/ErrorHandler.php
@@ -17,7 +17,7 @@ class ErrorHandler
 
     public function handleError($errno, $errstr, $errfile, $errline)
     {
-        if ($errno & $this->error_reporting === 0) {
+        if (error_reporting() === 0 || $errno & $this->error_reporting === 0) {
             return false;
         }
 

--- a/test/integration/test_test_runner.php
+++ b/test/integration/test_test_runner.php
@@ -214,7 +214,13 @@ describe('TestRunner', function ($ctx) {
                 expect($failures)->to->have->length(1);
                 expect($failures[0]->getBlock())->to->be->a('Matura\Blocks\Block');
             });
+        });
 
+        describe('Error Swallowing via @', function($ctx) {
+            it('should not capture @-swallowed errors', function($ctx) {
+                @(1/0);
+                expect(true)->to->equal(true);
+            });
         });
     });
 


### PR DESCRIPTION
I had some trouble when using Matura to test code in which I deliberately assign previously undefined indexes in an array, and use PHP's @-prefix method of suppressing the notices which result from doing so. Unfortunately, I found Matura still treats such suppressed notices as exceptions, and fails the tests in which they occur. Happily, the fix for this behavior was quite straightforward and uncomplicated.
